### PR TITLE
BUG - The following parameters should not be a list: additional_info.item

### DIFF
--- a/v2.x - 2.2/custom/catalog/controller/payment/mp_transparente.php
+++ b/v2.x - 2.2/custom/catalog/controller/payment/mp_transparente.php
@@ -218,7 +218,7 @@ class ControllerPaymentMPTransparente extends Controller {
 		$payment['additional_info']['payer']['address']['zip_code'] = $order_info['shipping_postcode'];
 
 		// Shipments Info
-		$payment['additional_info']['items'][] = $items;
+		$payment['additional_info']['items'] = $items;
 		$payment['additional_info']['shipments']['receiver_address']['zip_code'] = $order_info['shipping_postcode'];
 		$payment['additional_info']['shipments']['receiver_address']['street_name'] = $order_info['shipping_address_1'];
 		$payment['additional_info']['shipments']['receiver_address']['street_number'] = "-";


### PR DESCRIPTION
There is a bug in checkout where code sending array to array

For example:

The buggy code, send this json to checkout
"Items":[
         [
            {
               "id":"55",
               "title":"Cheese and Sauce Melting Tray",
               "description":"1 x Cheese and Sauce Melting Tray",
               "Quantity: 1,
               "unit_price":1,
               "picture_url":"https:\/\/5ainox.com.br\/image\/catalog\/imgprodutos\/Bandeja Melter Queijo e Sauces\/NOVO-LAYOUT-PRODUTOS-BANDEJA.png",
               "category_id":"others"
            }
         ]
      ]

After the correction, a json is sent as the official documentation requires.
"Items": [
      {
        "id": "PR0001",
        "title": "Mini Point",
        "description": "Product Point for bills with tarjetas via bluetooth",
        "picture_url": "https://http2.mlstatic.com/resources/frontend/statics/growth-sellers-landings/device-mlb-point-i_medium@2x.png",
        "category_id": "electronics",
        "Quantity: 1,
        "unit_price": 58.8
      }
    ],